### PR TITLE
fix: print styles after content

### DIFF
--- a/wpzoom-forms.php
+++ b/wpzoom-forms.php
@@ -2078,7 +2078,7 @@ class WPZOOM_Forms {
 			$styleOutput
 		);
 
-		$content = $style . $content;
+		$content = $content . $style;
 
 		return $content;
 	}


### PR DESCRIPTION
WordPress's block support processor targets the first HTML element in a `render_callback` output to apply the visibility classes. The `<style>` tag was being prepended to the output, making it the first element and causing those classes to be added to it instead of the `<form>` element. Moving the `<style>` output to after the form HTML resolves this.

<img width="332" height="227" alt="image" src="https://github.com/user-attachments/assets/d89bd606-6c86-4e55-a449-496d1df3d3c9" />
